### PR TITLE
Fix trapping of AJAX requests

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -30,63 +30,71 @@ class Module implements BootstrapListenerInterface
     {
         $config  = $e->getTarget()->getServiceManager()->get('Config');
         $config  = isset($config['view_manager']) ? $config['view_manager'] : array();
+        $request = $e->getRequest();
 
-        if ($e->getRequest() instanceof ConsoleRequest || empty($config['display_exceptions'])) {
+        if ($request instanceof ConsoleRequest || empty($config['display_exceptions'])) {
             return;
         }
 
         $this->run = new Run();
-        $this->run->register();
 
-        // set up whoops config
-        $prettyPageHandler = new PrettyPageHandler();
-
-        if (isset($config['editor'])) {
-
-            if ($config['editor'] == 'phpStorm') {
-                $localPath = null;
-                if (isset($config['local_path'])) {
-                    $localPath = $config['local_path'];
-                }
-
-                $prettyPageHandler->setEditor(
-                    function ($file, $line) use ($localPath) {
-
-                        if ($localPath) {
-                            // if your development server is not local it's good to map remote files to local
-                            $translations = array('^' . __DIR__ => $config['editor_path']); // change to your path
-
-                            foreach ($translations as $from => $to) {
-                                $file = preg_replace('#' . $from . '#', $to, $file, 1);
-                            }
-                        }
-
-                        return "pstorm://$file:$line";
-                    }
-                );
-            } else {
-                $prettyPageHandler->setEditor($config['editor']);
-            }
-        }
-
-        if (!empty($config['json_exceptions']['display'])) {
+        if( $request instanceof Request && $request->isXmlHttpRequest() )
+        {
             $jsonHandler = new JsonResponseHandler();
+            $jsonHandler->onlyForAjaxRequests(true);
 
             if (!empty($config['json_exceptions']['show_trace'])) {
                 $jsonHandler->addTraceToOutput(true);
             }
-            if (!empty($config['json_exceptions']['ajax_only'])) {
-                $jsonHandler->onlyForAjaxRequests(true);
-            }
 
             $this->run->pushHandler($jsonHandler);
         }
+        else
+        {
+            $prettyPageHandler = new PrettyPageHandler();
 
-        if (!empty($config['whoops_no_catch'])) {
+            if( isset($config['editor']) )
+            {
+                if( $config['editor'] == 'phpStorm' )
+                {
+                    $localPath = null;
+                    if( isset($config['local_path']) )
+                    {
+                        $localPath = $config['local_path'];
+                    }
+
+                    $prettyPageHandler->setEditor(
+                        function ( $file, $line ) use ( $localPath )
+                        {
+                            if( $localPath )
+                            {
+                                // if your development server is not local it's good to map remote files to local
+                                $translations = array( '^' . __DIR__ => $config['editor_path'] ); // change to your path
+
+                                foreach( $translations as $from => $to )
+                                {
+                                    $file = preg_replace( '#' . $from . '#', $to, $file, 1 );
+                                }
+                            }
+
+                            return "pstorm://$file:$line";
+                        }
+                    );
+                }
+                else
+                {
+                    $prettyPageHandler->setEditor( $config['editor'] );
+                }
+            }
+            $this->run->pushHandler($prettyPageHandler);
+        }
+
+        if (!empty($config['whoops_no_catch']))
+        {
             $this->noCatchExceptions = $config['whoops_no_catch'];
         }
 
-        $this->run->pushHandler($prettyPageHandler);
+        $this->run->register();
 
         $eventManager = $e->getTarget()->getEventManager();
         $eventManager->attach(MvcEvent::EVENT_RENDER_ERROR, array($this, 'prepareException'));


### PR DESCRIPTION
Right now the module returns full pretty-print pages for AJAX requests, which is pretty cumbersome.  This bootstrap solves the problem, initializing the right page printer for AJAX requests (or otherwise).

Thanks for having put this module together btw.

Cheers.
Alex