### PR TITLE
Fix ob_clean()

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -128,7 +128,7 @@ class Module implements BootstrapListenerInterface
                         header('HTTP/1.0 500 Internal Server Error', true, 500);
                     }
 
-                    ob_clean();
+                    if (ob_get_contents()) ob_end_clean();
                     $this->run->handleException($e->getParam('exception'));
                     break;
             }


### PR DESCRIPTION
Hi!

On my environment, I was having an error caused by the ob_clean(), making it impossible for the actual error to be displayed.

Error: ob_clean(): failed to delete buffer. No buffer to delete

I solved by changing the function from ob_clean to ob_end_clean, and putting an if statement to verify if it's possible to call the ob_end_clean().

I hope it helps. Thanks.