### PR TITLE
Update to support latest Whoops

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -10,6 +10,7 @@ use Zend\Mvc\MvcEvent;
 use Whoops\Run;
 use Whoops\Handler\JsonResponseHandler;
 use Whoops\Handler\PrettyPageHandler;
+use Zend\Http\PhpEnvironment\Request;
 
 class Module implements BootstrapListenerInterface
 {
@@ -38,10 +39,10 @@ class Module implements BootstrapListenerInterface
 
         $this->run = new Run();
 
+
         if( $request instanceof Request && $request->isXmlHttpRequest() )
         {
             $jsonHandler = new JsonResponseHandler();
-            $jsonHandler->onlyForAjaxRequests(true);
 
             if (!empty($config['json_exceptions']['show_trace'])) {
                 $jsonHandler->addTraceToOutput(true);


### PR DESCRIPTION
Wasn't trapping errors anymore, because the wrong Request type was being used, plus, there no longer is a ::onlyForAjaxRequests method.