### PR TITLE
load the config variable into callback scope

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -65,7 +65,7 @@ class Module implements BootstrapListenerInterface
                     }
 
                     $prettyPageHandler->setEditor(
-                        function ( $file, $line ) use ( $localPath )
+                        function ( $file, $line ) use ( $localPath, $config )
                         {
                             if( $localPath )
                             {


### PR DESCRIPTION
I'm trying to fix the file links, but whilst setting the config I encountered this bug.